### PR TITLE
fix empty page when no <a> tags

### DIFF
--- a/specials/SpecialHtml2Wiki.php
+++ b/specials/SpecialHtml2Wiki.php
@@ -1701,7 +1701,7 @@ HERE
             return false;
         }
         if ( $qp->length == 0 ) {
-            return false;
+            return $content;
         }
         foreach ( $qp as $anchor ) {
             if ( $anchor->hasAttr( 'href' ) ) {


### PR DESCRIPTION
Html2wiki created empty page when importing HTML without <a> tags. This was because `qpLinkToSpan` returned false which, concatenated with newlines, created empty page.